### PR TITLE
fix bug: udp is not working on Windows

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const path = require('path');
+const os = require('os');
 const pluginName = 'udp';
 
 function resolveController(controller, app) {
@@ -26,7 +27,13 @@ function EggUdp(app) {
 
   const dgram = require('dgram');
   const udp = dgram.createSocket('udp4');
-  udp.bind(udpPort);
+  const platform = os.platform();
+  // if platform is Windows, add exclusive prop onto bind method
+  if (platform === 'win32') {
+    udp.bind({ port: udpPort, exclusive: true });
+  } else {
+    udp.bind(udpPort);
+  }
   this.udp = udp;
 }
 


### PR DESCRIPTION
egg-udp cannot work correctly in Windows as _clustering dgram_  is not support Windows offically. [See Topic](https://stackoverflow.com/questions/39253637/how-to-run-node-cluster-on-windows)

So, if you want to continue use this egg-plugin, you have set _exclusive_ param when you bind port. Like this:

`udp.bind({port: 1900, exclusive: true})`

I've modified _app.js_ to detective OS automatically to fix the problem.